### PR TITLE
added changable maximal slider value

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - lower random and reset button will update all model parameters
 - the button `load RPS` will load rendering parameters from a .rps file (currently only shape, color and expression)
 - sliders are ordered according to the principal components
+- the maximal paarameter value corresponding to the sliders can be adjusted
 - press `Ctrl` to move pose with mouse (first click on face to activate the frame)
  
 ## For Developers:


### PR DESCRIPTION
The maximal value for all sliders is now a variable and can be changed. The implemented behaviour is:
- When changing the maximal value, the sliders change their position but the current model values are kept the same. Clamping of the values might happen if the maximum is lowered.
- When an rps file is loaded the maximal value is ceiled and set as the new maximum slider value.
- Initially the maximal slider value is set to 1.